### PR TITLE
ci/fix-release-action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
     with:
       prereleaseTag: ${{ inputs.prereleaseTag }}
       build: false
+      node-version: "18"
     secrets:
       NPM_PUBLISH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
     permissions:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "This plugin allows you to auto-increment any field on any mongoose schema that you wish.",
   "repository": {
     "type": "git",
-    "url": "git://github.com/codetunnel/mongoose-auto-increment.git"
+    "url": "git://github.com/Parsimotion/mongoose-auto-increment.git"
   },
   "dependencies": {
     "extend": "^3.0.0"
@@ -62,9 +62,6 @@
   "scripts": {
     "test": "node_modules/mocha/bin/mocha",
     "prepare": "husky"
-  },
-  "bugs": {
-    "url": "https://github.com/codetunnel/mongoose-auto-increment/issues"
   },
   "lint-staged": {
     "*.{js,jsx}": [


### PR DESCRIPTION
Agrego node v.18 para instalar dependencias correctamente al querer buildear en el workflow de release (build+release)

Test: https://github.com/Parsimotion/mongoose-auto-increment/actions/runs/17593288154